### PR TITLE
チュートリアル4　テンプレートに日付の表示形式を読み込む処理を記述

### DIFF
--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -60,7 +60,7 @@
                                 <td>
                                     <span class="label {{ $task->status_class }}">{{ $task->status_label }}</span>
                                 </td>
-                                <td>{{ $task->due_date }}</td>
+                                <td>{{ $task->formatted_due_date }}</td>
                                 <td><a href="#">編集</a></td>
                             </tr>
                         @endforeach


### PR DESCRIPTION
テンプレートに日付の表示形式を読み込む処理を記述しました。
<img width="857" alt="スクリーンショット 2020-06-24 16 21 08" src="https://user-images.githubusercontent.com/63224224/85514280-d8cca180-b636-11ea-8c94-37e3833afe93.png">
