### PR TITLE
チュートリアル5　テンプレート(create.blade.php)にエラー文言を表示させる記述を追加

### DIFF
--- a/resources/views/folders/create.blade.php
+++ b/resources/views/folders/create.blade.php
@@ -20,6 +20,15 @@
                 <nav class="panel panel-default">
                     <div class="panel-heading">フォルダを追加する</div>
                     <div class="panel-body">
+                        @if($errors->any())
+                            <div class="alert alert-danger">
+                                <ul>
+                                    @foreach($errors->all() as $message)
+                                        <li>{{ $message }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
                         <form action="{{ route('folders.create') }}" method="post">
                             @csrf
                             <div class="form-group">


### PR DESCRIPTION
テンプレート(create.blade.php)にエラー文言を表示させる記述を追加しました。
<img width="390" alt="スクリーンショット 2020-07-01 13 35 24" src="https://user-images.githubusercontent.com/63224224/86203407-e4244d80-bb9f-11ea-81ad-d933a62282a6.png">
