### PR TITLE
チュートリアル5　CreateFolder.php にattributes メソッドを追記

### DIFF
--- a/app/Http/Requests/CreateFolder.php
+++ b/app/Http/Requests/CreateFolder.php
@@ -24,7 +24,7 @@ class CreateFolder extends FormRequest
     public function rules()
     {
         return [
-            'title' => 'required',
+            'title' => 'required|max:20',
         ];
     }
 
@@ -34,4 +34,6 @@ class CreateFolder extends FormRequest
             'title' => 'フォルダ名',
         ];
     }
+
+
 }

--- a/app/Http/Requests/CreateFolder.php
+++ b/app/Http/Requests/CreateFolder.php
@@ -27,4 +27,11 @@ class CreateFolder extends FormRequest
             'title' => 'required',
         ];
     }
+
+    public function attributes()
+    {
+        return [
+            'title' => 'フォルダ名',
+        ];
+    }
 }

--- a/resources/lang/jp/validation.php
+++ b/resources/lang/jp/validation.php
@@ -79,7 +79,7 @@ return [
     'max' => [
         'numeric' => 'The :attribute may not be greater than :max.',
         'file' => 'The :attribute may not be greater than :max kilobytes.',
-        'string' => 'The :attribute may not be greater than :max characters.',
+        'string' => ':attribute は :max 文字以内で入力してください。',
         'array' => 'The :attribute may not have more than :max items.',
     ],
     'mimes' => 'The :attribute must be a file of type: :values.',


### PR DESCRIPTION
入力欄の名称をカスタマイズするためにCreateFolder.php にattributes メソッドを追記しました。
入力欄の名称「title」を日本語化するために、FormRequest クラスに attributes メソッドを追加しました。
<img width="383" alt="スクリーンショット 2020-07-01 14 01 44" src="https://user-images.githubusercontent.com/63224224/86205406-bbeb1d80-bba4-11ea-8350-6f0f38c23224.png">
