### PR TITLE
チュートリアル5　エラーの入力値を復元するために、create.blade.php のタイトル入力欄の input 要素に value 属…

### DIFF
--- a/resources/views/folders/create.blade.php
+++ b/resources/views/folders/create.blade.php
@@ -33,7 +33,7 @@
                             @csrf
                             <div class="form-group">
                                 <label for="title">フォルダ名</label>
-                                <input type="text" class="form-control" name="title" id="title" />
+                                <input type="text" class="form-control" name="title" id="title" value="{{ old('title') }}" />
                             </div>
                             <div class="text-right">
                                 <button type="submit" class="btn btn-primary">送信</button>


### PR DESCRIPTION
エラーの入力値を復元するために、create.blade.php のタイトル入力欄の input 要素に value 属性を追加しました。
<img width="379" alt="スクリーンショット 2020-07-01 14 58 58" src="https://user-images.githubusercontent.com/63224224/86208611-d7a5f200-bbab-11ea-9c35-48da2a48347f.png">
