### PR TITLE
チュートリアル6　バリデーションのメッセージの日本語化のためvalidation.php に date ルールの翻訳を追加

### DIFF
--- a/resources/lang/jp/validation.php
+++ b/resources/lang/jp/validation.php
@@ -31,7 +31,7 @@ return [
     ],
     'boolean' => 'The :attribute field must be true or false.',
     'confirmed' => 'The :attribute confirmation does not match.',
-    'date' => 'The :attribute is not a valid date.',
+    'date' => ':attribute には日付を入力してください。',
     'date_equals' => 'The :attribute must be a date equal to :date.',
     'date_format' => 'The :attribute does not match the format :format.',
     'different' => 'The :attribute and :other must be different.',


### PR DESCRIPTION
バリデーションのメッセージの日本語化のためjp/validation.php にdate ルールの翻訳を追加しました。