### PR TITLE
チュートリアル6　TaskTest.php にバリデーションエラーが発生するケースについてのテストを記述

### DIFF
--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -2,21 +2,56 @@
 
 namespace Tests\Feature;
 
+use App\Http\Requests\CreateTask;
+use Carbon\Carbon;
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class TaskTest extends TestCase
 {
-    /**
-     * A basic feature test example.
-     *
-     * @return void
-     */
-    public function testExample()
-    {
-        $response = $this->get('/');
+    // テストケースごとにデータベースをリフレッシュしてマイグレーションを再実行する
+    use RefreshDatabase;
 
-        $response->assertStatus(200);
+    /**
+     * 各テストメソッドの実行前に呼ばれる
+     */
+    public function setUp() :void
+    {
+        parent::setUp();
+
+        // テストケース実行前にフォルダデータを作成する
+        $this->seed('FoldersTableSeeder');
+    }
+
+    /**
+     * 期限日が日付ではない場合はバリデーションエラー
+     * @test
+     */
+    public function due_date_should_be_date()
+    {
+        $response = $this->post('/folders/1/tasks/create', [
+            'title' => 'Sample task',
+            'due_date' => 123, // 不正なデータ（数値）
+        ]);
+
+        $response->assertSessionHasErrors([
+            'due_date' => '期限日 には日付を入力してください。',
+        ]);
+    }
+
+    /**
+     * 期限日が過去日付の場合はバリデーションエラー
+     * @test
+     */
+    public function due_date_should_not_be_past()
+    {
+        $response = $this->post('/folders/1/tasks/create', [
+            'title' => 'Sample task',
+            'due_date' => Carbon::yesterday()->format('Y/m/d'), // 不正なデータ（昨日の日付）
+        ]);
+
+        $response->assertSessionHasErrors([
+            'due_date' => '期限日 には今日以降の日付を入力してください。',
+        ]);
     }
 }


### PR DESCRIPTION
TaskTest.php にバリデーションエラーが発生するケースについてのテストを記述しました。

コマンドラインでテストを実行し、不正な値を送信したときにバリデーションがうまくエラーを返すことが確認できました。
<img width="730" alt="スクリーンショット 2020-07-06 14 36 15" src="https://user-images.githubusercontent.com/63224224/86560355-0ac7f700-bf99-11ea-836a-1fc6b1da4caf.png">
