### PR TITLE
チュートリアル6　TaskTest.php に正常な場合と閏年の場合のテストコードを記述

### DIFF
--- a/.idea/todoapp.iml
+++ b/.idea/todoapp.iml
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" packagePrefix="Tests\" />
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/app" isTestSource="false" packagePrefix="App\" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/beyondcode/laravel-dump-server" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/composer" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/todoapp1" vcs="Git" />
   </component>
 </project>

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -43,7 +43,7 @@ class TaskController extends Controller
 
         $task = new Task();
         $task->title = $request->title;
-        $task->due_date = $request->due_date;
+        $task->due_date = $request->due_date;   // string YYYYY/MM/DD 形
 
         $current_folder->getTasksList()->save($task);
 

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -15,7 +15,7 @@ class TaskTest extends TestCase
     /**
      * 各テストメソッドの実行前に呼ばれる
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -53,5 +53,34 @@ class TaskTest extends TestCase
         $response->assertSessionHasErrors([
             'due_date' => '期限日 には今日以降の日付を入力してください。',
         ]);
+    }
+
+    /**
+     * 期限日が正常な場合
+     * @test
+     */
+    public function due_date_should_be_today()
+    {
+        $response = $this->post('/folders/1/tasks/create', [
+            'title' => 'Sample task',
+            'due_date' => Carbon::today()->format('Y/m/d'), // 正常なデータ
+        ]);
+
+        $response->assertStatus(302);
+    }
+
+    /**
+     * 期限日が閏年の場合
+     * 注意2048年以降にこのテストを行うとテストは通りません。おそらくその場合はありませんが。
+     * @test
+     */
+    public function due_date_should_be_uruudosi()
+    {
+        $response = $this->post('/folders/1/tasks/create', [
+            'title' => 'Sample task',
+            'due_date' => "2048/02/29", // 閏年のデータ
+        ]);
+
+        $response->assertStatus(302);
     }
 }


### PR DESCRIPTION
バリデーションのため、正常な場合と閏年の場合のテストコードを記述しました。

コマンドラインでテストを実行し、正常に動作していることが確認できました。
<img width="976" alt="スクリーンショット 2020-07-14 15 37 35" src="https://user-images.githubusercontent.com/63224224/87393205-c7006d80-c5e8-11ea-9ed7-e4bb37b2b1d2.png">

