### PR TITLE
チュートリアル8 BigIncrementsとincrementsの互換性が無かったため修正

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -14,7 +14,7 @@ class CreateUsersTable extends Migration
     public function up()
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->increments('id');
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();

--- a/database/migrations/2020_06_17_081549_create_folders_table.php
+++ b/database/migrations/2020_06_17_081549_create_folders_table.php
@@ -14,7 +14,7 @@ class CreateFoldersTable extends Migration
     public function up()
     {
         Schema::create('folders', function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->increments('id');
             $table->string('title', 20);
             $table->timestamps();
         });


### PR DESCRIPTION
BigIncrementsとincrementsの互換性が無かったため修正しました。

migrate:fresh コマンドでテーブルをすべて削除してマイグレーションを実行し直しました。
<img width="664" alt="スクリーンショット 2020-07-22 15 24 23" src="https://user-images.githubusercontent.com/63224224/88141978-aa3ee800-cc2f-11ea-809f-23ec0caa14e9.png">
