### PR TITLE
チュートリアル9　passwords.php メッセージファイルを日本語版のディレクトリにコピー

### DIFF
--- a/resources/lang/jp/passwords.php
+++ b/resources/lang/jp/passwords.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'password' => 'Passwords must be at least eight characters and match the confirmation.',
+    'reset' => 'パスワードを再設定しました。',
+    'sent' => 'パスワード再設定リンクを送信しました。',
+    'token' => 'トークンが無効です。',
+    'user' => "入力されたメールアドレスのユーザーは見つかりませんでした。",
+];


### PR DESCRIPTION
パスワード再発行のフローで用いられるメッセージを日本語化のため、passwords.php メッセージファイルを日本語版のディレクトリにコピーし、内容を変更しました。