### PR TITLE
チュートリアル10 存在しないコンテンツにアクセスされた場合のため、TaskController.phpにabort関数を追加

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -20,6 +20,10 @@ class TaskController extends Controller
         // 選ばれたフォルダを取得する
         $current_folder = Folder::find($id);
 
+        if (is_null($current_folder)) {
+            abort(404);
+        }
+
         // 選ばれたフォルダに紐づくタスクを取得する
         $tasks = $current_folder->getTasksList()->get();
 

--- a/app/Mail/ResetPassword.php
+++ b/app/Mail/ResetPassword.php
@@ -11,7 +11,7 @@ class ResetPassword extends Mailable
 {
     use Queueable, SerializesModels;
 
-    private $token;
+    public $token;
 
     /**
      * Create a new message instance.


### PR DESCRIPTION
存在しないコンテンツにアクセスされた場合のため、TaskController.phpにabort関数を追加しました。


■存在しないフォルダの ID を含むタスク一覧の URL にアクセスした場合（ /folders/999）
<img width="803" alt="スクリーンショット 2020-08-12 13 05 55" src="https://user-images.githubusercontent.com/63224224/89973971-bcdf9680-dc9c-11ea-8612-93837a22f7d6.png">
