### PR TITLE
チュートリアル10 abort(403) を呼び出す処理の重複を排除するために、ポリシークラスを作成

### DIFF
--- a/app/Policies/FolderPolicy.php
+++ b/app/Policies/FolderPolicy.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Policies;
+
+use App\Folder;
+use App\User;
+
+class FolderPolicy
+{
+    /**
+     * フォルダの閲覧権限
+     * @param User $user
+     * @param Folder $folder
+     * @return bool
+     */
+    public function view(User $user, Folder $folder)
+    {
+        return $user->id === $folder->user_id;
+    }
+}


### PR DESCRIPTION
権限がないコンテンツへのアクセスへの対策として、abort(403) を実行します。
abort(403) を呼び出す処理の重複を排除するために、ポリシークラスを作成しました。