### PR TITLE
チュートリアル10 TaskController.phpに閲覧する権限がない場合にabort(403) を実行するコードを追加

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -19,6 +19,10 @@ class TaskController extends Controller
      */
     public function index(Folder $folder)
     {
+        if (Auth::user()->id !== $folder->user_id) {
+            abort(403);
+        }
+
         // ユーザーのフォルダを取得する
         $folders = Auth::user()->folders()->get();
 


### PR DESCRIPTION
TaskController.phpに閲覧する権限がない場合にabort(403) を実行するコードを追加しました。