### PR TITLE
チュートリアル10 配列キーが本来"folder"になる箇所が”id“になっている箇所を"folder"に修正

### DIFF
--- a/app/Http/Controllers/FolderController.php
+++ b/app/Http/Controllers/FolderController.php
@@ -29,7 +29,7 @@ class FolderController extends Controller
         Auth::user()->folders()->save($folder);
 
         return redirect()->route('tasks.index', [
-            'id' => $folder->id,
+            'folder' => $folder->id,
         ]);
     }
 }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -93,7 +93,7 @@ class TaskController extends Controller
         $task->save();
 
         return redirect()->route('tasks.index', [
-            'id' => $task->folder_id,
+            'folder' => $task->folder_id,
         ]);
     }
 }

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -14,7 +14,7 @@
                     <div class="list-group">
                         @foreach($folders as $folder)
                             <a
-                                href="{{ route('tasks.index', ['id' => $folder->id]) }}"
+                                href="{{ route('tasks.index', ['folder' => $folder->id]) }}"
                                 class="list-group-item {{ $current_folder_id === $folder->id ? 'active' : '' }}"
                             >
                                 {{ $folder->title }}


### PR DESCRIPTION
配列キーが本来"folder"になる箇所が”id“になっている箇所を"folder"に修正しました。

変更前は、権限がないコンテンツへのアクセスした場合も404でしたが、修正後は403になることを確認しました。

■権限のある状態
<img width="943" alt="スクリーンショット 2020-09-01 15 50 18" src="https://user-images.githubusercontent.com/63224224/91811906-33076580-ec6b-11ea-90f5-b753db902dbe.png">

■権限のないコンテンツへのアクセス（変更前）
<img width="624" alt="スクリーンショット 2020-09-01 15 51 02" src="https://user-images.githubusercontent.com/63224224/91811913-36025600-ec6b-11ea-9e6b-38d64f761dc5.png">

■権限のないコンテンツへのアクセス（変更後）
<img width="565" alt="スクリーンショット 2020-09-01 15 50 39" src="https://user-images.githubusercontent.com/63224224/91811909-34389280-ec6b-11ea-93a4-e6068913ff01.png">